### PR TITLE
Right-click directive, add files, triggers across clients

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -7,7 +7,8 @@ angular.module('codeColab', [
   'angularTreeview',
   'codeColab.videochat',
   'codeColab.deploy',
-	'codeColab.services'
+	'codeColab.services',
+  'ng-context-menu'
 	])
 
 .config(['$routeProvider', function ($routeProvider) {

--- a/client/app/main/angular.treeview.js
+++ b/client/app/main/angular.treeview.js
@@ -22,6 +22,7 @@
 	</div>
 */
 
+
 'use strict';
 
 angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', function( $compile ) {
@@ -43,18 +44,83 @@ angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', fun
 			//children
 			var nodeChildren = attrs.nodeChildren || 'children';
 
+			//need to mess with z-indices
+			var menuStartDiv = "<div context-menu class=\"position-fixed\" data-target=\"{{node."+nodeId+"}}-menu\" ng-class=\"{ 'highlight': highlight, 'expanded' : expanded }\">"
+			var testDiv = '<div>{{node.'+nodeId+'}}</div>'
+			var menuEndDiv0 = '<div class="dropdown position-fixed" id="{{node.'+nodeId+'}}-menu">'+
+			  '<ul class="dropdown-menu" role="menu">'+
+			    '<li>'+
+			    	'test'+
+			    '</li>'+
+			    '<li>'+
+			    	'test0'+
+			    '</li>'+
+			    '<li>'+
+			    	'test1'+
+			    '</li>'+
+			    '<li>'+
+			      'test2'+
+			    '</li>'+
+			    '<li>'+
+			    	'test3'+
+			    '</li>'+
+			    '<li>'+
+			      'test4'+
+			    '</li>'+
+			  '</ul>'+
+			'</div>'
+
+			//need to change this based on whether node is file or folder, top or not - probably use ng-show
+			var menuEndDiv = '<div class="dropdown position-fixed" id="{{node.'+nodeId+'}}-menu" style="position:fixed">'+
+			  '<ul class="dropdown-menu" role="menu">'+
+			    '<li>'+
+			    	'<a class="pointer" role="menuitem" tabindex="1"'+
+			    		'ng-click="'+treeId+'.newFile(node)">'+
+			    			'Add file in this folder'+
+			    	'</a>'+
+			    '</li>'+
+			    '<li>'+
+			    	'<a class="pointer" role="menuitem" tabindex="2"'+
+			    		'ng-click="'+treeId+'.newFolder(node)">'+
+			    			'Add subfolder in this folder'+
+			    	'</a>'+
+			    '</li>'+
+			    '<li>'+
+			    	'<a class="pointer" role="menuitem" tabindex="3" '+
+			         'ng-click="'+treeId+'.newFile()">' +
+			         'Add file in root folder' +
+			      '</a>' +
+			    '</li>'+
+			    '<li>'+
+			      '<a class="pointer" role="menuitem" tabindex="4" '+
+			         'ng-click="'+treeId+'.newFolder()">'+
+			        'Add folder in root folder'+
+			      '</a>' +
+			    '</li>'+
+			    '<li>'+
+			      '<a class="pointer" role="menuitem" tabindex="5" '+
+			         'ng-click="'+treeId+'.deleteFile(node)">'+
+			        'Delete {{node.'+nodeLabel+'}}'+
+			      '</a>' +
+			    '</li>'+
+			  '</ul>'+
+			'</div>'
+
+			//need separate templates for files and folders, I think -AG
 			//tree template
 			var template =
 				'<ul>' +
-					'<li data-ng-repeat="node in ' + treeModel + '">' +
+					'<li data-ng-repeat="node in ' + treeModel + '">' + 
+						menuStartDiv + 
 						'<i class="collapsed fa fa-folder" data-ng-show="node.' + nodeChildren + '.length && node.collapsed" data-ng-click="' + treeId + '.selectNodeHead(node)"></i>' +
 						'<i class="expanded fa fa-folder-open" data-ng-show="node.' + nodeChildren + '.length && !node.collapsed" data-ng-click="' + treeId + '.selectNodeHead(node)"></i>' +
 						'<i class="normal fa fa-file-o" data-ng-hide="node.' + nodeChildren + '.length"></i> ' +
 						'<span data-ng-class="node.selected" data-ng-click="' + treeId + '.selectNodeLabel(node)">{{node.' + nodeLabel + '}}</span>' + //changed from .selectNodeLabel(node) to .selectNodeHead(node)
 						'<div data-ng-hide="node.collapsed" data-tree-id="' + treeId + '" data-tree-model="node.' + nodeChildren + '" data-node-id=' + nodeId + ' data-node-label=' + nodeLabel + ' data-node-children=' + nodeChildren + '></div>' +
+						"</div>"+
+						menuEndDiv +
 					'</li>' +
-				'</ul>';
-
+				'</ul>'
 
 			//check tree id, tree model
 			if( treeId && treeModel ) {
@@ -92,6 +158,91 @@ angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', fun
 							selectedNode.collapsed = !selectedNode.collapsed;
 						}
 					};
+					//need to set the treeId
+					//newFile function
+					scope[treeId].newFile = scope[treeId].newFile || function(node) {
+						var fileName = prompt('Enter the name of your new file (including the file extension, such as .js or .html).')
+						if(node) {
+							var newFile = {
+								children: [],
+								fullPath: node.fullPath+'/'+fileName,
+								label:fileName,
+								//probably need to update url and id after GitHub API call
+								url:'',
+								id:'',
+							}
+							scope.addFile(newFile,node.children)
+				// 			    scope.$parent.right.rDoc.submitOp([
+    //   {p:['treeStructure',0],ld:$scope.$parent.right.rDoc.snapshot.treeStructure[0],li:$scope.tree}
+    // ])
+							// node.children.push(newFile)
+						} else {
+							var newFile = {
+								children: [],
+								fullPath: fileName,
+								label:fileName,
+								//probably need to update url and id after GitHub API call
+								url:'',
+								id:'',
+								top:true,
+								type:'file'
+							}
+							scope.addFile(newFile,scope.tree)
+							// scope.tree.push(newFile)
+
+						}
+
+						// scope.treeChange()
+					}
+
+					//newFolder function
+					scope[treeId].newFolder = scope[treeId].newFolder || function(node) {
+						var folderName = prompt('Enter the name of your new folder.')
+						if(node) {
+							var placeholderFile = {
+								children: [],
+								fullPath: node.fullPath+'/'+folderName + '/placeholder.txt',
+								label:'placeholder.txt',
+								//probably need to update url and id after GitHub API call
+								url:'',
+								id:''
+							}
+
+							var newFolder = {
+								children:[placeholderFile],
+								fullPath: node.fullPath+'/'+folderName,
+								label:folderName,
+								url:'',
+								id:'',
+								type:'folder'
+							}
+							node.children.push(newFolder)
+						} else {
+							var placeholderFile = {
+								children: [],
+								fullPath: folderName + '/placeholder.txt',
+								label:'placeholder.txt',
+								//probably need to update url and id after GitHub API call
+								url:'',
+								id:''
+							}
+
+							var newFolder = {
+								children:[placeholderFile],
+								fullPath: folderName,
+								label:folderName,
+								url:'',
+								id:'',
+								top:true,
+								type:'folder'
+							}
+
+							scope.tree.push(newFolder)
+
+						}
+					}
+
+
 				}
 
 				//Rendering template.
@@ -100,6 +251,5 @@ angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', fun
 		}
 	};
 }]);
-
 
 

--- a/client/app/main/angular.treeview.js
+++ b/client/app/main/angular.treeview.js
@@ -46,29 +46,6 @@ angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', fun
 
 			//need to mess with z-indices
 			var menuStartDiv = "<div context-menu class=\"position-fixed\" data-target=\"{{node."+nodeId+"}}-menu\" ng-class=\"{ 'highlight': highlight, 'expanded' : expanded }\">"
-			var testDiv = '<div>{{node.'+nodeId+'}}</div>'
-			var menuEndDiv0 = '<div class="dropdown position-fixed" id="{{node.'+nodeId+'}}-menu">'+
-			  '<ul class="dropdown-menu" role="menu">'+
-			    '<li>'+
-			    	'test'+
-			    '</li>'+
-			    '<li>'+
-			    	'test0'+
-			    '</li>'+
-			    '<li>'+
-			    	'test1'+
-			    '</li>'+
-			    '<li>'+
-			      'test2'+
-			    '</li>'+
-			    '<li>'+
-			    	'test3'+
-			    '</li>'+
-			    '<li>'+
-			      'test4'+
-			    '</li>'+
-			  '</ul>'+
-			'</div>'
 
 			//need to change this based on whether node is file or folder, top or not - probably use ng-show
 			var menuEndDiv = '<div class="dropdown position-fixed" id="{{node.'+nodeId+'}}-menu" style="position:fixed">'+
@@ -172,30 +149,26 @@ angular.module( 'angularTreeview', [] ).directive( 'treeModel', ['$compile', fun
 								id:'',
 							}
 							scope.addFile(newFile,node.children)
-				// 			    scope.$parent.right.rDoc.submitOp([
-    //   {p:['treeStructure',0],ld:$scope.$parent.right.rDoc.snapshot.treeStructure[0],li:$scope.tree}
-    // ])
-							// node.children.push(newFile)
+
 						} else {
 							var newFile = {
 								children: [],
 								fullPath: fileName,
 								label:fileName,
-								//probably need to update url and id after GitHub API call
+								//need to update url and id after GitHub API call
 								url:'',
 								id:'',
 								top:true,
 								type:'file'
 							}
 							scope.addFile(newFile,scope.tree)
-							// scope.tree.push(newFile)
 
 						}
 
-						// scope.treeChange()
+						// the update of other users' tree is trigger in the controller
 					}
 
-					//newFolder function
+					//newFolder function - still needs a lot of work
 					scope[treeId].newFolder = scope[treeId].newFolder || function(node) {
 						var folderName = prompt('Enter the name of your new folder.')
 						if(node) {

--- a/client/app/main/fileStruct.js
+++ b/client/app/main/fileStruct.js
@@ -124,6 +124,7 @@ angular.module('codeColab.fileStruct', [])
     .then(function(data) {
       // console.log('new file data: ',data)
       //set file.id and file.url here - data.data.whatever
+      //might need to get sha from server
       file.id = data.data.fileId
       file.url = data.data.fileUrl
       arr.push(file)

--- a/client/app/main/fileStruct.js
+++ b/client/app/main/fileStruct.js
@@ -101,11 +101,11 @@ angular.module('codeColab.fileStruct', [])
     Share.loadFile($scope.$parent,file);
   }
 
-  $scope.treeChange = function() {
+  $scope.triggerShareTreeChange = function() {
     console.log('parent: ',$scope.$parent.right)
     // console.log('change: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0],$scope.tree)
-    $scope.$parent.right.rDoc.submitOp([
-      {p:['treeStructure',0],ld:$scope.$parent.right.rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
+    $scope.$parent.repoShare.rDoc.submitOp([
+      {p:['treeStructure',0],ld:$scope.$parent.repoShare.rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
     ])
     // console.log('new Value: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0])
   }
@@ -130,7 +130,7 @@ angular.module('codeColab.fileStruct', [])
       arr.push(file)
       // console.log('new file: ',file)
 
-      $scope.treeChange()
+      $scope.triggerShareTreeChange()
     })
   }
 

--- a/client/app/main/fileStruct.js
+++ b/client/app/main/fileStruct.js
@@ -100,6 +100,39 @@ angular.module('codeColab.fileStruct', [])
     $scope.$parent.editorWillLoad()
     Share.loadFile($scope.$parent,file);
   }
+
+  $scope.treeChange = function() {
+    console.log('parent: ',$scope.$parent.right)
+    // console.log('change: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0],$scope.tree)
+    $scope.$parent.right.rDoc.submitOp([
+      {p:['treeStructure',0],ld:$scope.$parent.right.rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
+    ])
+    // console.log('new Value: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0])
+  }
+
+  $scope.addFile = function(file,arr){
+    // console.log('addFile tree: ',$scope.tree)
+    // console.log('selected repo: ',$scope.selected, $scope.selected.slice($scope.selected.lastIndexOf('/')+1), $scope.selected.slice(0,$scope.selected.lastIndexOf('/')))
+    return $http({
+      method: 'POST',
+      url: '/api/files/newFile',
+      data: {
+        ownerAndRepo: $scope.selected,
+        fullPath : file.fullPath
+      }
+    })
+    .then(function(data) {
+      // console.log('new file data: ',data)
+      //set file.id and file.url here - data.data.whatever
+      file.id = data.data.fileId
+      file.url = data.data.fileUrl
+      arr.push(file)
+      // console.log('new file: ',file)
+
+      $scope.treeChange()
+    })
+  }
+
 })
 
 

--- a/client/app/main/fileStruct.js
+++ b/client/app/main/fileStruct.js
@@ -83,7 +83,7 @@ angular.module('codeColab.fileStruct', [])
 
   // console.log('final tree',results)
   $scope.tree = results;
-  // return results;
+
   }) // end of .then(function(bigTree))
 }  // end of getTree function
 
@@ -102,17 +102,12 @@ angular.module('codeColab.fileStruct', [])
   }
 
   $scope.triggerShareTreeChange = function() {
-    console.log('parent: ',$scope.$parent.right)
-    // console.log('change: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0],$scope.tree)
     $scope.$parent.repoShare.rDoc.submitOp([
       {p:['treeStructure',0],ld:$scope.$parent.repoShare.rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
     ])
-    // console.log('new Value: ',$scope.$parent.right.rDoc.snapshot.treeStructure[0])
   }
 
   $scope.addFile = function(file,arr){
-    // console.log('addFile tree: ',$scope.tree)
-    // console.log('selected repo: ',$scope.selected, $scope.selected.slice($scope.selected.lastIndexOf('/')+1), $scope.selected.slice(0,$scope.selected.lastIndexOf('/')))
     return $http({
       method: 'POST',
       url: '/api/files/newFile',
@@ -122,8 +117,7 @@ angular.module('codeColab.fileStruct', [])
       }
     })
     .then(function(data) {
-      // console.log('new file data: ',data)
-      //set file.id and file.url here - data.data.whatever
+      //set file.id and file.url here
       //might need to get sha from server
       file.id = data.data.fileId
       file.url = data.data.fileUrl

--- a/client/app/main/main.js
+++ b/client/app/main/main.js
@@ -62,7 +62,7 @@ angular.module('codeColab.main', [])
         bootbox.confirm("Are you sure you want to merge your changes into your master branch?", function (result) {
           if (result) {
             Share.mergeBranch($scope.selected, values.pullTitle, values.comments, $scope)
-            Share.updateRightOrigValue($scope,'CODECOLAB')
+            // had to put some of the editor updates in the .then of mergeBranch
           }
         })
       }
@@ -78,6 +78,14 @@ angular.module('codeColab.main', [])
 
   $scope.rebuild = function() {
     Share.rebuild($scope.selected);
+  }
+
+
+  $scope.triggerRightShareUpdate = function() {
+    console.log('update: ',$scope.repoShare.rDoc)
+    $scope.repoShare.rDoc.submitOp([
+      {p:['origTextTrigger',0],ld:0,li:0}
+    ])
   }
 
   $scope.init();

--- a/client/app/main/main.js
+++ b/client/app/main/main.js
@@ -29,6 +29,7 @@ angular.module('codeColab.main', [])
   }
 
   $scope.saveRepo = function(repo) {
+    $scope.currentFile = '';
     $scope.fileLoaded = false;
     Share.resetCM($scope)
     $scope.selected = repo.name;
@@ -38,6 +39,7 @@ angular.module('codeColab.main', [])
       FileStructDo.getTree($scope, repo, 'CODECOLAB')
     });
     Share.loadRepoShare($scope)
+    // Share.addRepoEventListeners($scope)
   }
 
   $scope.mergeModal = function(){

--- a/client/app/main/main.js
+++ b/client/app/main/main.js
@@ -39,7 +39,6 @@ angular.module('codeColab.main', [])
       FileStructDo.getTree($scope, repo, 'CODECOLAB')
     });
     Share.loadRepoShare($scope)
-    // Share.addRepoEventListeners($scope)
   }
 
   $scope.mergeModal = function(){

--- a/client/app/main/main.js
+++ b/client/app/main/main.js
@@ -37,6 +37,7 @@ angular.module('codeColab.main', [])
     promise.then(function(result) {
       FileStructDo.getTree($scope, repo, 'CODECOLAB')
     });
+    Share.loadRepoShare($scope)
   }
 
   $scope.mergeModal = function(){
@@ -61,7 +62,7 @@ angular.module('codeColab.main', [])
         bootbox.confirm("Are you sure you want to merge your changes into your master branch?", function (result) {
           if (result) {
             Share.mergeBranch($scope.selected, values.pullTitle, values.comments, $scope)
-            Share.updateRightOrigValue($scope)
+            Share.updateRightOrigValue($scope,'CODECOLAB')
           }
         })
       }

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -127,91 +127,25 @@ angular.module('codeColab.services', [])
         //need to do a submit op to 'seed' the json structure - this line will be changed if we want to add more stuff
         rDoc.submitOp([{p:[],od:null,oi:{origTextTrigger:[0],treeStructure:[0],commitAndMergeIndicators:{'commit':false,'merge':false}}}]) // might use set here instead
         
-        // console.log('created: ',rDoc)
       }
 
       rDoc.subscribe(function(err) {
-        // console.log('rDoc subscribed: ',rDoc)
 
-      //create new context for editor, tree, commit, and merge (maybe cursors and user list later on) to listen to
-      //we could probably create indicators to display which files have been changed/not committed, or are being worked in
-      $scope.repoShare.editingCxt = rDoc.createContext()
-      $scope.origTextTrigger = $scope.repoShare.editingCxt.createContextAt('origTextTrigger')
-      $scope.treeStructure = $scope.repoShare.editingCxt.createContextAt('treeStructure')
-      $scope.commitAndMergeIndicators = $scope.repoShare.editingCxt.createContextAt('commitAndMergeIndicators')
+        //create new context for editor, tree, commit, and merge (maybe cursors and user list later on) to listen to
+        //we could probably create indicators to display which files have been changed/not committed, or are being worked in
+        $scope.repoShare.editingCxt = rDoc.createContext()
+        $scope.origTextTrigger = $scope.repoShare.editingCxt.createContextAt('origTextTrigger')
+        $scope.treeStructure = $scope.repoShare.editingCxt.createContextAt('treeStructure')
+        $scope.commitAndMergeIndicators = $scope.repoShare.editingCxt.createContextAt('commitAndMergeIndicators')
 
-      //set variables that we watch for displaying commit/merge buttons
-      $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
-      $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
+        //set variables that we will eventually watch for displaying commit/merge buttons
+        $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
+        $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
 
-      addRepoEventListeners($scope)
-
-      //I used this stuff all for testing - delete it 
-
-      // setInterval(function() {
-      //   // console.log('interval: ',rDoc.snapshot.treeStructure[0],$scope.tree)
-      //   rDoc.submitOp([
-      //     {p:['origTextTrigger',0],ld:0,li:0}
-      //   ])
-      // },10000)
-      
-      // setTimeout(function() {
-      //   // console.log($scope.treeStructure.get())
-      //   // replace is what fires here - child op might fire also
-      //   // replace also fires even if new value is the same
-      //   rDoc.submitOp([
-      //     {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:[{label:'test100', fullPath: '', url:'', id:1, children:[]},{label:'test200', fullPath: '', url:'', id:2, children:[{label:'test2200', fullPath: '', url:'', id:3, children:[]}]}]}
-      //   ])
-      //   // for objects
-      //   // rDoc.submitOp([
-      //   //   {p:['treeStructure','a'],od:rDoc.snapshot.treeStructure.a,oi:Math.random()}
-      //   // ])
-      //   //for just inserting into arrays
-      //   // rDoc.submitOp([
-      //   //   {p:['treeStructure',10],li:Math.random()} //this one actually triggers insert
-      //   // ])
-      //   // $scope.treeStructure.push(Math.random())
-      //   console.log('treeStructure: ',$scope.treeStructure.get())
-      // },8500)
-
-      //pass context into attachCodeMirror function where appropriate
-      //add context event listeners
-
-      // $state.submitOp([
-      //   {p:['grid','values'],od:$state.snapshot.grid.values,oi:grid.values},
-      //   {p:['playerTurn'],od:$state.snapshot.playerTurn,oi:playerTurn}
-      // ]);
-
-        //if doc is new, set value based on GH master so we can update origDocuments collection
-
-        // var newRight = rDoc.getSnapshot()==='' ? CodeMirror.Doc('testing some stuff','javascript') : CodeMirror.Doc('testing some stuff','javascript')
-        // console.log('newRight value: ',newRight.getValue())
-
-        // $scope.CM.rightOriginal().swapDoc(newRight)
-        // console.log('rightOriginal value: ',$scope.CM.rightOriginal().getValue())
-
-        // need to restore this somehow - maybe?
-        // should probably get rid of this rightOrig CodeMirror - we will probably just load the value from GitHub each time the page loads
-        // rDoc.attachCodeMirror($scope.CM.rightOriginal(),$scope.origText)
-        // console.log('rDoc attached: ',rDoc)
-
-        // if($scope.origTextTrigger.get()==='') {
-        //   //should we run updaterightOrigValue here?
-        //   $scope.CM.rightOriginal().setValue(data)
-        //   console.log('snapshot: ',rDoc.getSnapshot())
-        //   // rDoc.submitOp([
-        //   //   {p:['origText'],od:'',oi:data}
-        //   // ])
-        //   $scope.origText.set(data)
-        //   console.log('snapshot 2: ',rDoc.getSnapshot())
-
-        //   // console.log('should be rDoc value: ',$scope.CM.rightOriginal().getValue())
-        // }
+        addRepoEventListeners($scope)
 
       })
 
-      //need to split this out so that it runs when a file is selected
-      // loadShare($scope,id,data)
     })
 
   }
@@ -223,6 +157,7 @@ angular.module('codeColab.services', [])
     //   $scope.right.rSjs.disconnect()
       // $scope.CM.rightOriginal().detachShareJsDoc()
     // }
+
     //just set value of rightOrig
     return $http ({
       method:'POST',
@@ -234,7 +169,6 @@ angular.module('codeColab.services', [])
       }
     })
     .then (function (data) {
-      console.log('new right value: ',data.data.file)
       // var newRight = CodeMirror.Doc(data.data.file,'javascript')
       // $scope.CM.rightOriginal().swapDoc(newRight)
       $scope.CM.rightOriginal().setValue(data.data.file)
@@ -245,9 +179,9 @@ angular.module('codeColab.services', [])
     if($scope.share) {
       $scope.share.doc.unsubscribe()
       $scope.share.sjs.disconnect()
+      $scope.CM.editor().detachShareJsDoc()
       // $scope.repoShare.rDoc.unsubscribe()
       // $scope.repoShare.rSjs.disconnect()
-      $scope.CM.editor().detachShareJsDoc()
       // $scope.CM.rightOriginal().detachShareJsDoc()
     }
 
@@ -268,7 +202,6 @@ angular.module('codeColab.services', [])
       $scope.share.doc.unsubscribe()
       $scope.share.sjs.disconnect()
       $scope.CM.editor().detachShareJsDoc()
-      //add stuff for other connection and rightOriginal() here
     }
 
     var socket = new BCSocket(null, {reconnect: true});
@@ -296,6 +229,7 @@ angular.module('codeColab.services', [])
         // probably some more efficient way to do this, but it works for now - if doc exists in
         // origDocs database but not in regular Docs database, this will copy the string into the editor immediately after
         // the subscription takes hold, which also copies it into the Docs database.
+        // need to verify that this part still works
         if(doc.getSnapshot()==='') {
           $scope.CM.editor().setValue($scope.CM.rightOriginal().getValue())
         }
@@ -328,18 +262,16 @@ angular.module('codeColab.services', [])
   var addRepoEventListeners = function($scope) {
     //create event listeners for each of the variables/contexts set upon repo selection/change
     $scope.treeStructure.on('replace', function() { 
-      console.log('replace entered',$scope.treeStructure.get()[0])
-
       //had to use timeout so that angular knows to render the scope change next chance it gets
       $timeout(function() {
         $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
         // $scope.$apply() - not needed for now
       })
-      // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
     })
 
+    //more work needed here
     $scope.commitAndMergeIndicators.on('replace', function() {
-      console.log('c/m replaced')
+      // console.log('c/m replaced')
       $timeout(function() {
         $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
         $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
@@ -347,13 +279,10 @@ angular.module('codeColab.services', [])
     })
 
     $scope.origTextTrigger.on('replace', function() {
-      console.log('fetching original text')
-      //somehow trigger fetching original text from master branch in GitHub, then setting right value to that text
-      // $timeout(function() {
-        if(!!$scope.currentFile) {
-        //for some reason this isn't firing anymore
-          updateRightOrigValue($scope,'master')
-        }
+      //$scope.currentFile is only set when a file is picked - if a repo is chosen but no file is entered, this was causing errors before
+      if(!!$scope.currentFile) {
+        updateRightOrigValue($scope,'master')
+      }
     })
 
   }
@@ -372,9 +301,7 @@ angular.module('codeColab.services', [])
     .then (function (data) {
       $scope.$parent.fileLoaded = true;
       $scope.$parent.currentFile.sha = data.data.fileSha;
-      console.log('fileSha: ',data.data.fileSha)
-      // this function doesn't exist anymore
-      // resetRightOrig($scope, id, data.data.file)
+      // console.log('fileSha: ',data.data.fileSha)
       loadShare($scope, file.id, data.data.file)
       updateRightOrigValue($scope,'master')
     });

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -184,16 +184,24 @@ angular.module('codeColab.services', [])
 
       $scope.treeStructure.on('replace', function() { 
         $scope.$parent.tree = $scope.treeStructure.get()[0]
+        $scope.$apply()
+        // $scope.treeStructure.get()[0].forEach(function(item) {
+        //   $scope.$parent.tree.push(item)
+        // })
+        // $scope.$parent.tree.push($scope.treeStructure.get()[0])
         // delete $scope.$parent.tree
         // how do I trigger a refresh?
         console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
       })
+
       $scope.treeStructure.on('child op', function(path,op) {
         console.log('child op',path,op)
       })
+      
       $scope.treeStructure.on('insert', function() {
         console.log('inserted')
       })
+      
       $scope.treeStructure.on('delete', function() {
         console.log('deleted')
       })
@@ -209,7 +217,7 @@ angular.module('codeColab.services', [])
         // replace is what fires here - child op might fire also
         // replace also fires even if new value is the same
         rDoc.submitOp([
-          {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:[{label:'test1', fullPath: '', url:'', id:1, children:[]},{label:'test2', fullPath: '', url:'', id:2, children:[{label:'test22', fullPath: '', url:'', id:3, children:[]}]}]}
+          {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:[{label:'test100', fullPath: '', url:'', id:1, children:[]},{label:'test200', fullPath: '', url:'', id:2, children:[{label:'test2200', fullPath: '', url:'', id:3, children:[]}]}]}
         ])
         // for objects
         // rDoc.submitOp([
@@ -249,7 +257,7 @@ angular.module('codeColab.services', [])
         // rDoc.attachCodeMirror($scope.CM.rightOriginal(),$scope.origText)
         // console.log('rDoc attached: ',rDoc)
 
-        if($scope.origText.get()==='') {
+        if($scope.origTextTrigger.get()==='') {
           //should we run updaterightOrigValue here?
           $scope.CM.rightOriginal().setValue(data)
           console.log('snapshot: ',rDoc.getSnapshot())

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -1,7 +1,9 @@
 angular.module('codeColab.services', [])
 
 
-.factory('Share', function ($http, $window, $location, $q) {
+.factory('Share', function ($http, $window, $location, $q, $timeout) {
+  var path;
+>>>>>>> combined with addFiles stuff and have it mostly working - need to refactor quite a bit though
   var ce;
 
   var getRepos = function ($scope) {
@@ -173,7 +175,7 @@ angular.module('codeColab.services', [])
       }
 
       rDoc.subscribe(function(err) {
-        console.log('rDoc subscribed: ',rDoc)
+        // console.log('rDoc subscribed: ',rDoc)
 
       //create new context for editor, tree, commit, and merge (maybe cursors and user list) to listen to
       //we could probably create indicators to display which files have been changed/not committed
@@ -183,59 +185,57 @@ angular.module('codeColab.services', [])
       $scope.commitAndMergeIndicators = editingCxt.createContextAt('commitAndMergeIndicators')
 
       $scope.treeStructure.on('replace', function() { 
-        $scope.$parent.tree = $scope.treeStructure.get()[0]
-        $scope.$apply()
-        // $scope.treeStructure.get()[0].forEach(function(item) {
-        //   $scope.$parent.tree.push(item)
-        // })
-        // $scope.$parent.tree.push($scope.treeStructure.get()[0])
-        // delete $scope.$parent.tree
-        // how do I trigger a refresh?
-        console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
+        console.log('replace entered',$scope.treeStructure.get()[0])
+        $timeout(function() {
+          $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
+          // $scope.$apply()
+        })
+        // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
       })
 
-      $scope.treeStructure.on('child op', function(path,op) {
-        console.log('child op',path,op)
-      })
+      // $scope.treeStructure.on('child op', function(path,op) {
+      //   console.log('child op',path,op)
+      // })
       
-      $scope.treeStructure.on('insert', function() {
-        console.log('inserted')
-      })
+      // $scope.treeStructure.on('insert', function() {
+      //   console.log('inserted')
+      // })
       
-      $scope.treeStructure.on('delete', function() {
-        console.log('deleted')
-      })
+      // $scope.treeStructure.on('delete', function() {
+      //   console.log('deleted')
+      // })
 
       $scope.commitAndMergeIndicators.on('replace', function() {
         console.log('c/m replaced')
         $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
         $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
       })
+
+      // setInterval(function() {
+      //   console.log('interval: ',rDoc.snapshot.treeStructure[0],$scope.tree)
+      //   rDoc.submitOp([
+      //     {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
+      //   ])
+      // },4500)
       
-      setTimeout(function() {
-        // console.log($scope.treeStructure.get())
-        // replace is what fires here - child op might fire also
-        // replace also fires even if new value is the same
-        rDoc.submitOp([
-          {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:[{label:'test100', fullPath: '', url:'', id:1, children:[]},{label:'test200', fullPath: '', url:'', id:2, children:[{label:'test2200', fullPath: '', url:'', id:3, children:[]}]}]}
-        ])
-        // for objects
-        // rDoc.submitOp([
-        //   {p:['treeStructure','a'],od:rDoc.snapshot.treeStructure.a,oi:Math.random()}
-        // ])
-        //for just inserting into arrays
-        // rDoc.submitOp([
-        //   {p:['treeStructure',10],li:Math.random()} //this one actually triggers insert
-        // ])
-        // $scope.treeStructure.push(Math.random())
-        console.log('treeStructure: ',$scope.treeStructure.get())
-      },8500)
-
-      console.log(rDoc.getSnapshot(),rDoc.snapshot)
-
-      console.log($scope.origTextTrigger.get(),rDoc.getSnapshot().treeStructure[0],$scope.commitAndMergeIndicators.get())
-
-      console.log('added to scope: ',$scope.origText,$scope.treeStructure,$scope.commitAndMergeIndicators)
+      // setTimeout(function() {
+      //   // console.log($scope.treeStructure.get())
+      //   // replace is what fires here - child op might fire also
+      //   // replace also fires even if new value is the same
+      //   rDoc.submitOp([
+      //     {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:[{label:'test100', fullPath: '', url:'', id:1, children:[]},{label:'test200', fullPath: '', url:'', id:2, children:[{label:'test2200', fullPath: '', url:'', id:3, children:[]}]}]}
+      //   ])
+      //   // for objects
+      //   // rDoc.submitOp([
+      //   //   {p:['treeStructure','a'],od:rDoc.snapshot.treeStructure.a,oi:Math.random()}
+      //   // ])
+      //   //for just inserting into arrays
+      //   // rDoc.submitOp([
+      //   //   {p:['treeStructure',10],li:Math.random()} //this one actually triggers insert
+      //   // ])
+      //   // $scope.treeStructure.push(Math.random())
+      //   console.log('treeStructure: ',$scope.treeStructure.get())
+      // },8500)
 
       //pass context into attachCodeMirror function where appropriate
       //add context event listeners
@@ -254,6 +254,7 @@ angular.module('codeColab.services', [])
         // console.log('rightOriginal value: ',$scope.CM.rightOriginal().getValue())
 
         // need to restore this somehow - maybe?
+        // should probably get rid of this rightOrig CodeMirror - we will probably just load the value from GitHub each time the page loads
         // rDoc.attachCodeMirror($scope.CM.rightOriginal(),$scope.origText)
         // console.log('rDoc attached: ',rDoc)
 

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -139,52 +139,16 @@ angular.module('codeColab.services', [])
       $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
       $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
 
-      //create event listeners for each of the above variables/contexts
-      $scope.treeStructure.on('replace', function() { 
-        console.log('replace entered',$scope.treeStructure.get()[0])
 
-        //had to use timeout so that angular knows to render the scope change next chance it gets
-        $timeout(function() {
-          $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
-          // $scope.$apply() - not needed for now
-        })
-        // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
-      })
-
-      // $scope.treeStructure.on('child op', function(path,op) {
-      //   console.log('child op',path,op)
-      // })
-      
-      // $scope.treeStructure.on('insert', function() {
-      //   console.log('inserted')
-      // })
-      
-      // $scope.treeStructure.on('delete', function() {
-      //   console.log('deleted')
-      // })
-
-      $scope.commitAndMergeIndicators.on('replace', function() {
-        console.log('c/m replaced')
-        $timeout(function() {
-          $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
-          $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
-        })
-      })
-
-      $scope.origTextTrigger.on('replace', function() {
-        console.log('fetching original text')
-        //somehow trigger fetching original text from master branch in GitHub, then setting right value to that text
-
-      })
 
       //I used this stuff all for testing - delete it 
 
       // setInterval(function() {
-      //   console.log('interval: ',rDoc.snapshot.treeStructure[0],$scope.tree)
+      //   // console.log('interval: ',rDoc.snapshot.treeStructure[0],$scope.tree)
       //   rDoc.submitOp([
-      //     {p:['treeStructure',0],ld:rDoc.snapshot.treeStructure[0],li:JSON.stringify($scope.tree)}
+      //     {p:['origTextTrigger',0],ld:0,li:0}
       //   ])
-      // },4500)
+      // },10000)
       
       // setTimeout(function() {
       //   // console.log($scope.treeStructure.get())
@@ -265,10 +229,8 @@ angular.module('codeColab.services', [])
       }
     })
     .then (function (data) {
-      // need to change all of this stuff
-
-      // console.log(data)
-      var newRight = CodeMirror.Doc(data.data.file,'javascript')
+      console.log('new right value: ',data.data.file)
+      // var newRight = CodeMirror.Doc(data.data.file,'javascript')
       // $scope.CM.rightOriginal().swapDoc(newRight)
       $scope.CM.rightOriginal().setValue(data.data.file)
     });
@@ -336,6 +298,36 @@ angular.module('codeColab.services', [])
         $scope.CM.editor().setOption('readOnly',false)
         // console.log('after subscribed',doc.getSnapshot(),codeEditor.editor().getValue())
         ce = $scope.CM
+
+        //create event listeners for each of the variables/contexts set upon repo selection/change
+        $scope.treeStructure.on('replace', function() { 
+          console.log('replace entered',$scope.treeStructure.get()[0])
+
+          //had to use timeout so that angular knows to render the scope change next chance it gets
+          $timeout(function() {
+            $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
+            // $scope.$apply() - not needed for now
+          })
+          // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
+        })
+
+        $scope.commitAndMergeIndicators.on('replace', function() {
+          console.log('c/m replaced')
+          $timeout(function() {
+            $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
+            $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
+          })
+        })
+
+        $scope.origTextTrigger.on('replace', function() {
+          console.log('fetching original text')
+          //somehow trigger fetching original text from master branch in GitHub, then setting right value to that text
+          // $timeout(function() {
+            if($scope.selectedFile) {
+              updateRightOrigValue($scope,'master')
+            }
+          // })
+        })
 
         //below is for the text editor spinner
         $scope.$parent.$apply(function () {
@@ -485,7 +477,8 @@ angular.module('codeColab.services', [])
         }else {
           bootbox.alert("Merge Successful")
           that.checkForApp($scope, repo)
-          //rightOrig value update is triggered in the controller
+          updateRightOrigValue($scope,'master')
+          $scope.triggerRightShareUpdate()
         }
       }
     })

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -230,7 +230,8 @@ angular.module('codeColab.services', [])
         // probably some more efficient way to do this, but it works for now - if doc exists in
         // origDocs database but not in regular Docs database, this will copy the string into the editor immediately after
         // the subscription takes hold, which also copies it into the Docs database.
-        // need to verify that this part still works
+        // this ordering works for now, but ideally we would promisify this in some way; if the GitHub call is too slow, 
+        // this logic might not work correctly
         if(doc.getSnapshot()==='') {
           $scope.CM.editor().setValue($scope.CM.rightOriginal().getValue())
         }
@@ -303,8 +304,8 @@ angular.module('codeColab.services', [])
       $scope.$parent.fileLoaded = true;
       $scope.$parent.currentFile.sha = data.data.fileSha;
       // console.log('fileSha: ',data.data.fileSha)
-      loadShare($scope, file.id, data.data.file)
       updateRightOrigValue($scope,'master')
+      loadShare($scope, file.id, data.data.file)
     });
   }
 

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -96,7 +96,6 @@ angular.module('codeColab.services', [])
   }
 
   var loadRepoShare = function($scope) {
-    // console.log('right: ',id)
     if($scope.repoShare) {
       $scope.repoShare.rDoc.unsubscribe()
       $scope.repoShare.rSjs.disconnect()
@@ -111,9 +110,11 @@ angular.module('codeColab.services', [])
 
     var rSocket = new BCSocket(null, {reconnect: true});
     var rSjs = new sharejs.Connection(rSocket);
+
     //need to hash this in the server in some way, for unique encrypted storage
+    //need to switch this to origDocs eventually
     var rDoc = rSjs.get('adamShareTest', $scope.selected);
-    // var rDoc = rSjs.get('adamShareTest', 'testDoc');
+    
     $scope.repoShare = {rDoc: rDoc, rSjs: rSjs}
 
     rDoc.subscribe()

--- a/client/app/services.js
+++ b/client/app/services.js
@@ -100,7 +100,12 @@ angular.module('codeColab.services', [])
     if($scope.repoShare) {
       $scope.repoShare.rDoc.unsubscribe()
       $scope.repoShare.rSjs.disconnect()
+
+      //probably should move these context destroy operations into a separate function.
       $scope.repoShare.editingCxt.destroy()
+      $scope.origTextTrigger.destroy()
+      $scope.treeStructure.destroy()
+      $scope.commitAndMergeIndicators.destroy()
       // $scope.CM.rightOriginal().detachShareJsDoc()
     }
 
@@ -139,7 +144,7 @@ angular.module('codeColab.services', [])
       $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
       $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
 
-
+      addRepoEventListeners($scope)
 
       //I used this stuff all for testing - delete it 
 
@@ -299,36 +304,7 @@ angular.module('codeColab.services', [])
         // console.log('after subscribed',doc.getSnapshot(),codeEditor.editor().getValue())
         ce = $scope.CM
 
-        //create event listeners for each of the variables/contexts set upon repo selection/change
-        $scope.treeStructure.on('replace', function() { 
-          console.log('replace entered',$scope.treeStructure.get()[0])
-
-          //had to use timeout so that angular knows to render the scope change next chance it gets
-          $timeout(function() {
-            $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
-            // $scope.$apply() - not needed for now
-          })
-          // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
-        })
-
-        $scope.commitAndMergeIndicators.on('replace', function() {
-          console.log('c/m replaced')
-          $timeout(function() {
-            $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
-            $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
-          })
-        })
-
-        $scope.origTextTrigger.on('replace', function() {
-          console.log('fetching original text')
-          //somehow trigger fetching original text from master branch in GitHub, then setting right value to that text
-          // $timeout(function() {
-            if($scope.selectedFile) {
-              updateRightOrigValue($scope,'master')
-            }
-          // })
-        })
-
+        
         //below is for the text editor spinner
         $scope.$parent.$apply(function () {
           $scope.$parent.editorHasLoaded()
@@ -349,6 +325,39 @@ angular.module('codeColab.services', [])
     $scope.share = {sjs:sjs,doc:doc}
   }
 
+  var addRepoEventListeners = function($scope) {
+    //create event listeners for each of the variables/contexts set upon repo selection/change
+    $scope.treeStructure.on('replace', function() { 
+      console.log('replace entered',$scope.treeStructure.get()[0])
+
+      //had to use timeout so that angular knows to render the scope change next chance it gets
+      $timeout(function() {
+        $scope.$parent.tree = JSON.parse($scope.treeStructure.get()[0])
+        // $scope.$apply() - not needed for now
+      })
+      // console.log('tree replaced: ',$scope.$parent.tree,$scope.tree,$scope.treeStructure.get()[0])
+    })
+
+    $scope.commitAndMergeIndicators.on('replace', function() {
+      console.log('c/m replaced')
+      $timeout(function() {
+        $scope.commitInd = $scope.commitAndMergeIndicators.get().commit
+        $scope.mergeInd = $scope.commitAndMergeIndicators.get().merge
+      })
+    })
+
+    $scope.origTextTrigger.on('replace', function() {
+      console.log('fetching original text')
+      //somehow trigger fetching original text from master branch in GitHub, then setting right value to that text
+      // $timeout(function() {
+        if(!!$scope.currentFile) {
+        //for some reason this isn't firing anymore
+          updateRightOrigValue($scope,'master')
+        }
+    })
+
+  }
+
   var loadFile = function ($scope, file) {
     $scope.$parent.currentFile = file;
 
@@ -363,10 +372,10 @@ angular.module('codeColab.services', [])
     .then (function (data) {
       $scope.$parent.fileLoaded = true;
       $scope.$parent.currentFile.sha = data.data.fileSha;
-      console.log('fileSha: ',that.fileSha,data.data.fileSha)
+      console.log('fileSha: ',data.data.fileSha)
       // this function doesn't exist anymore
       // resetRightOrig($scope, id, data.data.file)
-      loadShare($scope, id, data.data.file)
+      loadShare($scope, file.id, data.data.file)
       updateRightOrigValue($scope,'master')
     });
   }
@@ -504,7 +513,8 @@ angular.module('codeColab.services', [])
     checkName: checkName,
     mergeBranch: mergeBranch,
     loadRepoShare: loadRepoShare,
-    updateRightOrigValue: updateRightOrigValue
+    updateRightOrigValue: updateRightOrigValue,
+    addRepoEventListeners: addRepoEventListeners
   }
 })
 

--- a/client/index.html
+++ b/client/index.html
@@ -21,6 +21,7 @@
     <script src="app/deploy/deploy.js"></script>
     <script src="app/main/fileStruct.js"></script>
     <script type="text/javascript" src="app/main/angular.treeview.js"></script>
+    <script type="text/javascript" src="./bower_components/ng-context-menu/dist/ng-context-menu.js"></script>
     <script type="text/javascript" src="app/videochat/videochat.js"></script>
     <link rel="stylesheet" type="text/css" href="styles/css/angular.treeview.css">
     <link rel="stylesheet" href="styles/css/font-awesome.min.css">

--- a/client/styles/css/angular.treeview.css
+++ b/client/styles/css/angular.treeview.css
@@ -56,6 +56,26 @@ div[data-tree-model] li .selected {
   padding: 1px 5px;
 }
 
+div[data-tree-model] .dropdown-menu li {
+  position: relative;
+  padding: 0;
+  line-height: 20px;
+}
+ 
+div[data-tree-model] .dropdown-menu li a {
+  padding: 3px 5px;
+  cursor: pointer;
+}
+ 
+div[data-tree-model] div.dropdown {
+  z-index: 6;
+}
 
-
+#area {
+  z-index: -1;
+}
+ 
+#files {
+  z-index: 5;
+}
 

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ var express = require('express'),
     monk =require ('monk'),
     docs = require('./documents/documents.js'),
     fileStruct = require('./fileStruct.js'),
+    // db = monk('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810'),
     db = monk('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810'),
     cookieParser = require('cookie-parser'),
     session = require('express-session'),
@@ -24,6 +25,7 @@ var express = require('express'),
     http    = require( 'http' ),
     server  = http.createServer( app ),
     liveDBMongoClient = require('livedb-mongo'),
+    // dbClient =liveDBMongoClient('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810',
     dbClient =liveDBMongoClient('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810',
       {safe: true}),
     backend = livedb.client(dbClient),
@@ -543,6 +545,7 @@ app.use(browserChannel( function(client) {
   };
 
   client.on('message', function(data) {
+    console.log(data)
     stream.push(data);
   });
 

--- a/server/server.js
+++ b/server/server.js
@@ -217,8 +217,10 @@ app.post('/api/getUpdatedFile', function (req, res) {
     headers: {'User-Agent': req.user.username}
   },
     function(err, resp, body) {
-      var fileSha=JSON.parse(body).sha,
-          file = atob(JSON.parse(body).content);
+      console.log('request: ',filePath,ownerAndRepo,branch)
+      var fileSha=JSON.parse(body).sha;
+      // console.log('file: ',JSON.parse(body))
+      var file = atob(JSON.parse(body).content);
       // docs.sendDoc(db, file, fileId, fileSha);
       var salt = '$2a$10$JX4yfb1a6c0Ec6yYxkleie' //same as salt in tree
       

--- a/server/server.js
+++ b/server/server.js
@@ -198,7 +198,7 @@ app.post('/api/files', function (req, res) {
       // console.log('content: ',JSON.parse(body).content)
       var file = atob(JSON.parse(body).content);
       // docs.sendDoc(db, file, fileId, fileSha);
-      res.status(200).send({file:file});
+      res.status(200).send({file:file, fileSha:fileSha});
     });
 })
 
@@ -206,12 +206,14 @@ app.post('/api/files', function (req, res) {
 //when trying to update the rightOriginal side.
 //https://api.github.com/repos/adamlg/chatitude/contents/ff.html?ref=CODECOLAB
 app.post('/api/getUpdatedFile', function (req, res) {
-  var filePath = req.body.filePath,
-      ownerAndRepo = req.body.ownerAndRepo //need to get this from $scope.selected
+  var filePath = req.body.filePath
+  var ownerAndRepo = req.body.ownerAndRepo //need to get this from $scope.selected
+  var branch = req.body.branch
+
   request({
-    //we get them from the CODECOLAB branch so we don't have to wait for the pull request to go through -
+    // on merge, we get them from the CODECOLAB branch so we don't have to wait for the pull request to go through -
     // watch this for bugs, and switch to master if needed
-    url: 'https://api.github.com/repos/' + ownerAndRepo + '/contents/' + filePath + '?ref=CODECOLAB&access_token=' + req.session.token,
+    url: 'https://api.github.com/repos/' + ownerAndRepo + '/contents/' + filePath + '?ref=' + branch + '&access_token=' + req.session.token,
     headers: {'User-Agent': req.user.username}
   },
     function(err, resp, body) {
@@ -220,8 +222,8 @@ app.post('/api/getUpdatedFile', function (req, res) {
       // docs.sendDoc(db, file, fileId, fileSha);
       var salt = '$2a$10$JX4yfb1a6c0Ec6yYxkleie' //same as salt in tree
       
-      file.id = '0'+bcrypt.hashSync(repo+'/'+item.path+'Code-Colab-Extra-Salt',salt)
-      file.url = 'https://api.github.com/repos/' + ownerAndRepo + '/contents/' + item.path
+      file.id = '0'+bcrypt.hashSync(ownerAndRepo+'/'+filePath+'Code-Colab-Extra-Salt',salt)
+      file.url = 'https://api.github.com/repos/' + ownerAndRepo + '/contents/' + filePath
 
       res.status(200).send({file:file, fileSha:fileSha});
     })
@@ -556,6 +558,8 @@ app.post('/api/files/newFile', function(req, res) {
     // console.log('newFile body: ',body)
     // var file = atob(JSON.parse(body).content);
     // docs.sendDoc(db, file, fileId, fileSha);
+    var fileSha = JSON.parse(body).sha
+
     var salt = '$2a$10$JX4yfb1a6c0Ec6yYxkleie' //same as salt in tree
     
     fileId = '0'+bcrypt.hashSync(req.body.ownerAndRepo+'/'+req.body.fullPath+'Code-Colab-Extra-Salt',salt)
@@ -563,7 +567,7 @@ app.post('/api/files/newFile', function(req, res) {
 
     // console.log(body)
     //will use response to get url and id of newly created file, and return it to our client-side function
-    res.status(200).send({fileId:fileId,fileUrl:fileUrl})
+    res.status(200).send({fileId:fileId,fileUrl:fileUrl,fileSha:fileSha})
   })
 })
 

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,6 @@ var express = require('express'),
     monk =require ('monk'),
     docs = require('./documents/documents.js'),
     fileStruct = require('./fileStruct.js'),
-    // db = monk('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810'),
     db = monk('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810'),
     cookieParser = require('cookie-parser'),
     session = require('express-session'),
@@ -25,7 +24,6 @@ var express = require('express'),
     http    = require( 'http' ),
     server  = http.createServer( app ),
     liveDBMongoClient = require('livedb-mongo'),
-    // dbClient =liveDBMongoClient('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810',
     dbClient =liveDBMongoClient('mongodb://heroku_app36344810:slkuae58qandst6sk9r58r57bl@ds031812.mongolab.com:31812/heroku_app36344810',
       {safe: true}),
     backend = livedb.client(dbClient),
@@ -195,7 +193,6 @@ app.post('/api/files', function (req, res) {
   },
     function (err, resp, body) {
       var fileSha=JSON.parse(body).sha
-      // console.log('content: ',JSON.parse(body).content)
       var file = atob(JSON.parse(body).content);
       // docs.sendDoc(db, file, fileId, fileSha);
       res.status(200).send({file:file, fileSha:fileSha});
@@ -207,7 +204,7 @@ app.post('/api/files', function (req, res) {
 //https://api.github.com/repos/adamlg/chatitude/contents/ff.html?ref=CODECOLAB
 app.post('/api/getUpdatedFile', function (req, res) {
   var filePath = req.body.filePath
-  var ownerAndRepo = req.body.ownerAndRepo //need to get this from $scope.selected
+  var ownerAndRepo = req.body.ownerAndRepo //we get this from $scope.selected
   var branch = req.body.branch
 
   request({
@@ -217,9 +214,7 @@ app.post('/api/getUpdatedFile', function (req, res) {
     headers: {'User-Agent': req.user.username}
   },
     function(err, resp, body) {
-      console.log('request: ',filePath,ownerAndRepo,branch)
       var fileSha=JSON.parse(body).sha;
-      // console.log('file: ',JSON.parse(body))
       var file = atob(JSON.parse(body).content);
       // docs.sendDoc(db, file, fileId, fileSha);
       var salt = '$2a$10$JX4yfb1a6c0Ec6yYxkleie' //same as salt in tree
@@ -545,7 +540,6 @@ app.post('/api/merge', function (req, res) {
 
 app.post('/api/files/newFile', function(req, res) {
   console.log('newFile path: ','https://api.github.com/repos/' + req.body.ownerAndRepo + '/contents/' + req.body.fullPath + '?access_token=' + req.session.token)
-  // res.sendStatus(200)
   request.put({
     url: 'https://api.github.com/repos/' + req.body.ownerAndRepo + '/contents/' + req.body.fullPath + '?access_token=' + req.session.token,
     headers: {'User-Agent': req.session.username},
@@ -557,8 +551,6 @@ app.post('/api/files/newFile', function(req, res) {
     }
   }, 
   function(err, resp, body) {
-    // console.log('newFile body: ',body)
-    // var file = atob(JSON.parse(body).content);
     // docs.sendDoc(db, file, fileId, fileSha);
     var fileSha = JSON.parse(body).sha
 
@@ -567,7 +559,6 @@ app.post('/api/files/newFile', function(req, res) {
     fileId = '0'+bcrypt.hashSync(req.body.ownerAndRepo+'/'+req.body.fullPath+'Code-Colab-Extra-Salt',salt)
     fileUrl = 'https://api.github.com/repos/' + req.body.ownerAndRepo + '/contents/' + req.body.fullPath
 
-    // console.log(body)
     //will use response to get url and id of newly created file, and return it to our client-side function
     res.status(200).send({fileId:fileId,fileUrl:fileUrl,fileSha:fileSha})
   })
@@ -585,7 +576,6 @@ app.use(browserChannel( function(client) {
   };
 
   client.on('message', function(data) {
-    console.log(data)
     stream.push(data);
   });
 


### PR DESCRIPTION
1.) You can now right-click on the file structure to bring up a custom menu.  Right now you can only add files to the current folder or root folder, though.  Soon you will also be able to create folders and delete files.

2.) You can add files, and when that happens it triggers a change in the other clients in that same repo to update their tree.

3.) The triggers that current work across clients in the same repo are tree updates and branch merges.  There are a couple more that are in progress.
